### PR TITLE
Fix incompatibility with ModuleDoc().

### DIFF
--- a/valentyusb/usbcore/cpu/cdc_eptri.py
+++ b/valentyusb/usbcore/cpu/cdc_eptri.py
@@ -188,6 +188,8 @@ class CDCUsbPHY(Module, AutoDoc, ModuleDoc):
         product,
         manufacturer):
 
+        ModuleDoc.__init__(self)
+
         # Create the eptri USB interface
         usb = TriEndpointInterface(iobuf, debug=debug)
         #usb.finalize()


### PR DESCRIPTION
Without this call to `ModuleDoc.__init__(self)`, `generate_docs()` fails.
Fix provided by zyp on #litex.

Traceback (most recent call last):
  File "mydesign.py", line 299, in <module>
    main()
  File "mydesign.py", line 292, in main
    generate_docs(soc, "build/"+target+"/documentation")
  File ".../litex/litex/litex/soc/doc/__init__.py", line 98, in generate_docs
    documented_region = DocumentedCSRRegion(
  File ".../litex/litex/litex/soc/doc/csr.py", line 80, in __init__
    docs = module.get_module_documentation()
  File ".../litex/litex/litex/soc/integration/doc.py", line 141, in gatherer
    return sorted(r, key=lambda x: x.duid)
  File ".../litex/litex/litex/soc/integration/doc.py", line 141, in <lambda>
    return sorted(r, key=lambda x: x.duid)
  File ".../litex/migen/migen/fhdl/module.py", line 136, in __getattr__
    raise AttributeError("'"+self.__class__.__name__+"' object has no attribute '"+name+"'")
AttributeError: 'CDCUsbPHY' object has no attribute 'duid'
